### PR TITLE
Call updateMarkerIcon after setting cache key

### DIFF
--- a/packages/core/android/src/main/java/expo/modules/gaodemap/overlays/MarkerView.kt
+++ b/packages/core/android/src/main/java/expo/modules/gaodemap/overlays/MarkerView.kt
@@ -393,6 +393,7 @@ class MarkerView(context: Context, appContext: AppContext) : ExpoView(context, a
      */
     fun setCacheKey(key: String?) {
         cacheKey = key
+        updateMarkerIcon()
     }
 
     /**


### PR DESCRIPTION

fix: #31


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Marker icons now update immediately when the associated cache key changes, ensuring consistent visual rendering without requiring additional events to trigger updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->