### PR TITLE
fix(core): iOS Polyline dotted 虚线不生效 —— isDotted 从未写入 renderer

### DIFF
--- a/packages/core/ios/overlays/PolylineView.swift
+++ b/packages/core/ios/overlays/PolylineView.swift
@@ -121,6 +121,8 @@ class PolylineView: ExpoView {
         if renderer == nil, let polyline = polyline {
             renderer = MAPolylineRenderer(polyline: polyline)
             renderer?.lineWidth = CGFloat(strokeWidth)
+            // MALineDashType 是 C enum,Swift 导入为全局常量 kMALineDashType*;square 与 Android DOTTEDLINE_TYPE_SQUARE 对齐
+            renderer?.lineDashType = isDotted ? kMALineDashTypeSquare : kMALineDashTypeNone
             
             if let url = textureUrl {
                 loadTexture(url: url, renderer: renderer!)


### PR DESCRIPTION
## 问题

`<Polyline dotted={true} />` 在 iOS 上始终渲染为实线;Android 端(`DOTTEDLINE_TYPE_SQUARE`)正常。

## 根因

`packages/core/ios/overlays/PolylineView.swift` 中,`isDotted` 只在 `setDotted` 里被保存,`getRenderer()` 创建 `MAPolylineRenderer` 时从未设置 `lineDashType` —— 即 `isDotted` 从头到尾没有被消费。`setDotted` 虽然会 `renderer = nil` + `forceRerender()` 重建渲染器,但重建出来的 renderer 同样没有 `lineDashType`,所以运行时切换也无效。

## 修复

在 `getRenderer()` 中按 `isDotted` 写入 `renderer.lineDashType`(`square`,与 Android 的 `DOTTEDLINE_TYPE_SQUARE` 对齐)。配合现有的 `setDotted` 重建逻辑,初始渲染与运行时切换均生效。

一个易踩的细节:`MALineDashType` 是裸 C enum(非 `NS_ENUM`),Swift 侧导入为全局常量 `kMALineDashTypeSquare` / `kMALineDashTypeNone`,不能写 `.square`(编译不过),已在代码注释中说明。

## 验证

我们的生产 App(RN 0.86 新架构,expo-gaode-map 2.2.36 → 2.2.40)一直以 patch-package 携带同一修复:iOS 真机上虚线正常渲染,`dotted` 运行时切换(实线↔虚线)正常,与 Android 端视觉一致。

https://claude.ai/code/session_01RDGWh87bRfJ1Cxztrx84mt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dotted line rendering for polylines when enabled.
  * Solid line rendering remains available by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->