### PR TITLE
合并#49

### DIFF
--- a/packages/navigation/ios/map/overlays/PolylineView.swift
+++ b/packages/navigation/ios/map/overlays/PolylineView.swift
@@ -121,6 +121,8 @@ class PolylineView: ExpoView {
         if renderer == nil, let polyline = polyline {
             renderer = MAPolylineRenderer(polyline: polyline)
             renderer?.lineWidth = CGFloat(strokeWidth)
+            // MALineDashType 是 C enum,Swift 导入为全局常量 kMALineDashType*;square 与 Android DOTTEDLINE_TYPE_SQUARE 对齐
+            renderer?.lineDashType = isDotted ? kMALineDashTypeSquare : kMALineDashTypeNone
             
             if let url = textureUrl {
                 loadTexture(url: url, renderer: renderer!)

--- a/packages/navigation/src/__tests__/ios-polyline-native-source.test.ts
+++ b/packages/navigation/src/__tests__/ios-polyline-native-source.test.ts
@@ -1,0 +1,19 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+describe('iOS Polyline native source guards', () => {
+  const polylineViewSource = fs.readFileSync(
+    path.resolve(__dirname, '../../ios/map/overlays/PolylineView.swift'),
+    'utf8'
+  );
+
+  it('applies the dotted prop when creating the renderer', () => {
+    const getRendererSource = polylineViewSource.match(
+      /func getRenderer\(\) -> MAOverlayRenderer \{[\s\S]*?return renderer!\n    \}/
+    )?.[0];
+
+    expect(getRendererSource).toContain(
+      'renderer?.lineDashType = isDotted ? kMALineDashTypeSquare : kMALineDashTypeNone'
+    );
+  });
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * iOS map polylines now correctly display dotted lines when the dotted style is enabled.
  * Solid polylines continue to render without dash styling.

* **Tests**
  * Added coverage to verify dotted and solid polyline rendering behavior on iOS.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->